### PR TITLE
Feature actionless url api

### DIFF
--- a/src/Bonnier/RestBase.php
+++ b/src/Bonnier/RestBase.php
@@ -54,7 +54,7 @@ class RestBase {
             $url = $url . '?'.http_build_query($data);
         }
 
-        $apiUrl = rtrim($this->getServiceUrl(), '/') . '/' . $url;
+        $apiUrl = rtrim($this->getServiceUrl(), '/') . ($url ? '/' . $url : '');
 
         $this->httpRequest->setUrl($apiUrl);
 


### PR DESCRIPTION
Make it possible to not paste actions through $url. This allows for usage of API's that receives its actions through the data.

Ex. 
request= {
    "action":"saveComment",
    "data":{
        "post_id":1234
        "comment":"This is a comment"
    }
}

I understand that this goes against some rest principles, and perhaps we should make a postBaes? Regardless, thought is planted, we can work with it.
