### PR TITLE
Changed restbase to support actionless urls (actions defined in the d…

### DIFF
--- a/src/Bonnier/RESTBase.php
+++ b/src/Bonnier/RESTBase.php
@@ -63,7 +63,7 @@ abstract class RESTBase {
             $postData = $data;
         }
 
-        $apiUrl = rtrim($this->getServiceUrl(), '/') . '/' . $url;
+        $apiUrl = rtrim($this->getServiceUrl(), '/') . ($url ? '/' . $url : '');
 
         $headers = array('Authorization: Basic ' . base64_encode(sprintf('%s:%s', $this->username, $this->secret)));
         if($this->postJson && count($postData) > 0) {


### PR DESCRIPTION
Make it possible to not paste actions through $url. This allows for usage of API's that receives its actions through the data.

Ex. 
request= {
    "action":"saveComment",
    "data":{
        "post_id":1234
        "comment":"This is a comment"
    }
}

I understand that this goes against some rest principles, and perhaps we should make a postBaes? Regardless, thought is planted, we can work with it.
